### PR TITLE
Remove requires of config, it's deprecated

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,3 @@
-var config = require('./config');
-
 module.exports = function(grunt) {
 
   // Project configuration.

--- a/ddocs/index.js
+++ b/ddocs/index.js
@@ -1,6 +1,5 @@
 var fs = require('fs'),
     path = require('path'),
-    config = require(path.join(__dirname, '..', 'config')),
   // root of the Cloudant URL we'll push to
     admin_url = "https://" + process.env.USERNAME + ":" + process.env.PASSWORD + "@" + process.env.USERNAME + ".cloudant.com",
   // get paths to every design doc in the folder, excluding this file


### PR DESCRIPTION
a few stray files were still requiring the old config.js file, which was deprecated in favor of environmental settings.
