### PR TITLE
Remove unnecessary newPath variable

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -21,8 +21,7 @@ module.exports = function(app, prefix, admin_url){
   // from the prefix and a given path
   // good for, say, API versioning
   function makePath(path){
-    var newPath = '/' + [prefix, path].join('/');
-    return newPath;
+    return '/' + [prefix, path].join('/');
   }
 
   app.get(makePath('crud'), function(req, res){


### PR DESCRIPTION
`newPath` was created only to be `return`ed one line later, so I removed it.
