### PR TITLE
`doctype 5` is deprecated, you must now use `doctype html` #9

### DIFF
--- a/views/layout.jade
+++ b/views/layout.jade
@@ -1,4 +1,4 @@
-doctype 5
+doctype html
 html
   head
     title Express-Cloudant


### PR DESCRIPTION
Simple fix to support jade 1.0. I believe the the github editor stripped the last linebreak. #9
